### PR TITLE
Gitignore the base ROM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+;Prevent sharing ROMs accidentally.
+*.gb
+*.gbc

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 ;Prevent sharing ROMs accidentally.
 *.gb
 *.gbc
+
+;Prevent committing compiled object code
+*.o


### PR DESCRIPTION
This file will prevent the base ROM from appearing in git status, as well as text-editor integrated git clients such as brackets-git.